### PR TITLE
feat: adiciona local.properties

### DIFF
--- a/android/local.properties
+++ b/android/local.properties
@@ -1,0 +1,1 @@
+sdk.dir=C\:\\Android\\Sdk


### PR DESCRIPTION
## Descrição das Alterações
- Adicionado o arquivo `android/local.properties` com o caminho padrão do SDK do Android.
- Configuração necessária para build do projeto no ambiente local.

## Motivação  
Essa alteração permite que novos contribuidores possam:  
✅ Compilar o projeto sem erros de "SDK não encontrado".  
✅ Manter uma referência da estrutura de diretórios padrão.  

## Como Testar  
1. Clone o repositório  
2. Verifique se o arquivo `android/local.properties` foi criado com o conteúdo:  
   ```properties
     sdk.dir=C\:\\Android\\Sdk